### PR TITLE
feat: overhaul quest create/edit pages and filters

### DIFF
--- a/src/features/quests/components/data-table.tsx
+++ b/src/features/quests/components/data-table.tsx
@@ -45,18 +45,19 @@ export const QuestsDataTable = ({ columns, isAdmin }: DataTableProps) => {
     pageIndex: 0,
     pageSize: 20,
   })
+  const pickSingle = (id: string, fallback = ''): string => {
+    const raw = columnFilters.find((f) => f.id === id)?.value as unknown
+    if (Array.isArray(raw)) return (raw[0] ?? fallback) as string
+    if (typeof raw === 'string') return raw
+    return fallback
+  }
 
   const search =
     (columnFilters.find((f) => f.id === 'title')?.value as string) ?? ''
-  const group =
-    (columnFilters.find((f) => f.id === 'group')?.value as TaskGroup | 'all') ??
-    'all'
-  const type =
-    (columnFilters.find((f) => f.id === 'type')?.value as string) ?? ''
-  const provider =
-    (columnFilters.find((f) => f.id === 'provider')?.value as string) ?? ''
-  const visible =
-    (columnFilters.find((f) => f.id === 'visible')?.value as string) ?? ''
+  const group = (pickSingle('group', 'all') as TaskGroup | 'all')
+  const type = pickSingle('type', '')
+  const provider = pickSingle('provider', '')
+  const visible = pickSingle('visible', '')
   const sort = sorting[0]
     ? `${sorting[0].id}:${sorting[0].desc ? 'desc' : 'asc'}`
     : 'order_by:asc'

--- a/src/features/quests/data/data.tsx
+++ b/src/features/quests/data/data.tsx
@@ -18,7 +18,10 @@ export const providers = [
   { value: 'twitter', label: 'Twitter' },
   { value: 'telegram', label: 'Telegram' },
   { value: 'discord', label: 'Discord' },
+  { value: 'matrix', label: 'Matrix' },
   { value: 'walme', label: 'Walme' },
+  { value: 'monetag', label: 'Monetag' },
+  { value: 'adsgram', label: 'AdsGram' },
 ]
 
 export const visibilities = [

--- a/src/features/quests/pages.tsx
+++ b/src/features/quests/pages.tsx
@@ -1,5 +1,9 @@
 import { useParams, useNavigate } from '@tanstack/react-router'
-import type { Task } from '@/types/tasks'
+import { Header } from '@/components/layout/header'
+import { Main } from '@/components/layout/main'
+import { ProfileDropdown } from '@/components/profile-dropdown'
+import { Search } from '@/components/search'
+import { ThemeSwitch } from '@/components/theme-switch'
 import { QuestForm } from './QuestForm'
 import { useCreateQuest, useQuest, useUpdateQuest } from './api'
 
@@ -7,30 +11,60 @@ export const QuestCreatePage = () => {
   const create = useCreateQuest()
   const nav = useNavigate({})
   return (
-    <QuestForm
-      onSubmit={async (v: Partial<Task>) => {
-        await create.mutateAsync(v)
-        nav({ to: '/quests' })
-      }}
-    />
+    <>
+      <Header fixed>
+        <Search />
+        <div className='ml-auto flex items-center space-x-4'>
+          <ThemeSwitch />
+          <ProfileDropdown />
+        </div>
+      </Header>
+      <Main>
+        <div className='mb-4'>
+          <h2 className='text-2xl font-bold tracking-tight'>New Quest</h2>
+          <p className='text-muted-foreground'>Create a new quest.</p>
+        </div>
+        <QuestForm
+          onSubmit={async (v) => {
+            await create.mutateAsync(v)
+            nav({ to: '/quests' })
+          }}
+        />
+      </Main>
+    </>
   )
 }
 
 export const QuestEditPage = () => {
-  const params = useParams({ from: '/_authenticated/quests/$id' })
-  const id = Number(params.id)
-  const { data } = useQuest(id)
-  const update = useUpdateQuest(id)
+  const { id } = useParams({ from: '/_authenticated/quests/$id' })
+  const questId = Number(id)
+  const { data } = useQuest(questId)
+  const update = useUpdateQuest(questId)
   const nav = useNavigate({})
 
   if (!data) return null
   return (
-    <QuestForm
-      initial={data}
-      onSubmit={async (v: Partial<Task>) => {
-        await update.mutateAsync(v)
-        nav({ to: '/quests' })
-      }}
-    />
+    <>
+      <Header fixed>
+        <Search />
+        <div className='ml-auto flex items-center space-x-4'>
+          <ThemeSwitch />
+          <ProfileDropdown />
+        </div>
+      </Header>
+      <Main>
+        <div className='mb-4'>
+          <h2 className='text-2xl font-bold tracking-tight'>Edit Quest #{id}</h2>
+          <p className='text-muted-foreground'>Update quest properties.</p>
+        </div>
+        <QuestForm
+          initial={data}
+          onSubmit={async (v) => {
+            await update.mutateAsync(v)
+            nav({ to: '/quests' })
+          }}
+        />
+      </Main>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- rebuild QuestForm with UI kit inputs, validation, icon upload, and conditional fields
- wrap quest create/edit pages with header/main layout and titles
- normalize faceted filter values in quests table and extend provider list

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_b_68a057d430148328a96a9318ffe9efb0