### PR TITLE
feat: enforce admin routes with beforeLoad guard

### DIFF
--- a/src/auth/guards.ts
+++ b/src/auth/guards.ts
@@ -1,0 +1,15 @@
+import { redirect } from '@tanstack/react-router'
+import { userManager } from '@/auth/oidc'
+import { hasAdminRole } from './roles'
+
+export const requireAdminBeforeLoad = async () => {
+  if (import.meta.env.VITE_USE_FAKE_AUTH === 'true') return
+  try {
+    const user = await userManager.getUser()
+    if (!user?.profile || !hasAdminRole(user.profile)) {
+      throw redirect({ to: '/quests', replace: true })
+    }
+  } catch {
+    throw redirect({ to: '/quests', replace: true })
+  }
+}

--- a/src/auth/oidc.ts
+++ b/src/auth/oidc.ts
@@ -1,4 +1,4 @@
-import { WebStorageStateStore } from 'oidc-client-ts'
+import { UserManager, WebStorageStateStore } from 'oidc-client-ts'
 import type { AuthProviderProps } from 'react-oidc-context'
 
 const rawBaseEnv = import.meta.env.VITE_APP_BASE_URL as string | undefined
@@ -27,3 +27,5 @@ export const oidcConfig: AuthProviderProps = {
     window.history.replaceState({}, document.title, window.location.pathname)
   },
 }
+
+export const userManager = new UserManager(oidcConfig)

--- a/src/auth/roles.ts
+++ b/src/auth/roles.ts
@@ -1,0 +1,15 @@
+export const extractRoles = (profile: unknown): string[] => {
+  if (!profile || typeof profile !== 'object') return []
+  const realm = (profile as { realm_access?: { roles?: unknown } }).realm_access?.roles
+  if (Array.isArray(realm)) return realm.filter((r): r is string => typeof r === 'string')
+  const account = (profile as {
+    resource_access?: { account?: { roles?: unknown } }
+  }).resource_access?.account?.roles
+  if (Array.isArray(account)) return account.filter((r): r is string => typeof r === 'string')
+  const direct = (profile as { roles?: unknown }).roles
+  if (Array.isArray(direct)) return direct.filter((r): r is string => typeof r === 'string')
+  return []
+}
+
+export const hasAdminRole = (profile: unknown): boolean =>
+  extractRoles(profile).includes('admin')

--- a/src/components/layout/nav-group.tsx
+++ b/src/components/layout/nav-group.tsx
@@ -8,7 +8,6 @@ import {
 } from '@/components/ui/collapsible'
 import {
   SidebarGroup,
-  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
@@ -28,12 +27,11 @@ import {
 } from '../ui/dropdown-menu'
 import { NavCollapsible, NavItem, NavLink, type NavGroup } from './types'
 
-export function NavGroup({ title, items }: NavGroup) {
+export function NavGroup({ items }: NavGroup) {
   const { state, isMobile } = useSidebar()
   const href = useLocation({ select: (location) => location.href })
   return (
     <SidebarGroup>
-      {/* <SidebarGroupLabel>{title}</SidebarGroupLabel> */}
       <SidebarMenu>
         {items.map((item) => {
           const key = `${item.title}-${item.url}`

--- a/src/components/layout/team-switcher.tsx
+++ b/src/components/layout/team-switcher.tsx
@@ -1,20 +1,5 @@
 import * as React from 'react'
-import { ChevronsUpDown, Plus } from 'lucide-react'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuShortcut,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
-import {
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-  useSidebar,
-} from '@/components/ui/sidebar'
+import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar'
 
 export function TeamSwitcher({
   teams,
@@ -25,61 +10,19 @@ export function TeamSwitcher({
     plan: string
   }[]
 }) {
-  const { isMobile } = useSidebar()
-  const [activeTeam, setActiveTeam] = React.useState(teams[0])
+  const [activeTeam] = React.useState(teams[0])
 
   return (
     <SidebarMenu>
       <SidebarMenuItem>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <SidebarMenuButton
-              size='lg'
-              className='data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground'
-            >
-              <div className='bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg'>
-                <activeTeam.logo className='size-4' />
-              </div>
-              <div className='grid flex-1 text-left text-sm leading-tight'>
-                <span className='truncate font-semibold'>
-                  {activeTeam.name}
-                </span>
-                {/* <span className='truncate text-xs'>{activeTeam.plan}</span> */}
-              </div>
-              {/* <ChevronsUpDown className='ml-auto' /> */}
-            </SidebarMenuButton>
-          </DropdownMenuTrigger>
-          {/* <DropdownMenuContent
-            className='w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg'
-            align='start'
-            side={isMobile ? 'bottom' : 'right'}
-            sideOffset={4}
-          >
-            <DropdownMenuLabel className='text-muted-foreground text-xs'>
-              Teams
-            </DropdownMenuLabel>
-            {teams.map((team, index) => (
-              <DropdownMenuItem
-                key={team.name}
-                onClick={() => setActiveTeam(team)}
-                className='gap-2 p-2'
-              >
-                <div className='flex size-6 items-center justify-center rounded-sm border'>
-                  <team.logo className='size-4 shrink-0' />
-                </div>
-                {team.name}
-                <DropdownMenuShortcut>⌘{index + 1}</DropdownMenuShortcut>
-              </DropdownMenuItem>
-            ))}
-            <DropdownMenuSeparator />
-            <DropdownMenuItem className='gap-2 p-2'>
-              <div className='bg-background flex size-6 items-center justify-center rounded-md border'>
-                <Plus className='size-4' />
-              </div>
-              <div className='text-muted-foreground font-medium'>Add team</div>
-            </DropdownMenuItem>
-          </DropdownMenuContent> */}
-        </DropdownMenu>
+        <SidebarMenuButton size='lg' className='data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground'>
+          <div className='bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg'>
+            <activeTeam.logo className='size-4' />
+          </div>
+          <div className='grid flex-1 text-left text-sm leading-tight'>
+            <span className='truncate font-semibold'>{activeTeam.name}</span>
+          </div>
+        </SidebarMenuButton>
       </SidebarMenuItem>
     </SidebarMenu>
   )

--- a/src/features/quests/api.real.ts
+++ b/src/features/quests/api.real.ts
@@ -33,7 +33,7 @@ export const useQuests = (query: {
     )
   ).toString()
   return useQuery<QuestsResponse>({
-    queryKey: ['quests', params],
+    queryKey: ['quests', params, search],
     queryFn: () =>
       http<QuestsResponse>(`/quests?${search}`, { token: getAccessToken() }),
   })

--- a/src/router.guards.tsx
+++ b/src/router.guards.tsx
@@ -1,9 +1,0 @@
-import { redirect } from '@tanstack/react-router'
-import { useAppAuth } from '@/auth/provider'
-
-export const useRequireAdmin = () => {
-  const auth = useAppAuth()
-  if (!auth.hasRole('admin')) {
-    throw redirect({ to: '/quests' })
-  }
-}

--- a/src/routes/_authenticated/quests/$id.tsx
+++ b/src/routes/_authenticated/quests/$id.tsx
@@ -1,7 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { requireAdminBeforeLoad } from '@/auth/guards'
 import { QuestEditPage } from '@/features/quests/pages'
 
 export const Route = createFileRoute('/_authenticated/quests/$id')({
+  beforeLoad: requireAdminBeforeLoad,
   component: QuestEditPage,
   staticData: { title: 'Edit Quest', breadcrumb: 'Edit Quest' },
 })
+

--- a/src/routes/_authenticated/quests/new.tsx
+++ b/src/routes/_authenticated/quests/new.tsx
@@ -1,9 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { useRequireAdmin } from '@/router.guards'
+import { requireAdminBeforeLoad } from '@/auth/guards'
 import { QuestCreatePage } from '@/features/quests/pages'
 
 export const Route = createFileRoute('/_authenticated/quests/new')({
-  beforeLoad: useRequireAdmin,
+  beforeLoad: requireAdminBeforeLoad,
   component: QuestCreatePage,
   staticData: { title: 'New Quest', breadcrumb: 'New Quest' },
 })
+


### PR DESCRIPTION
## Summary
- replace component guard with `requireAdminBeforeLoad` using OIDC user manager
- share role parsing via new `extractRoles` helper
- clean sidebar components and fix quests API lint issues

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68a0ccc01bb08328924000a974480c68