### PR TITLE
feat: add quest icon drag-and-drop uploader

### DIFF
--- a/src/components/image-dropzone.tsx
+++ b/src/components/image-dropzone.tsx
@@ -1,0 +1,85 @@
+import { useDropzone, type FileError } from 'react-dropzone'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { toast } from 'sonner'
+import { mediaErrors } from '@/errors/media'
+
+const dropErrors: Record<FileError['code'], string> = {
+  'file-too-large': mediaErrors.size,
+  'file-invalid-type': mediaErrors.type,
+}
+
+interface ImageDropzoneProps {
+  preview?: string
+  onFile: (file: File) => void
+  onClear: () => void
+  disabled?: boolean
+}
+
+export const ImageDropzone = ({
+  preview,
+  onFile,
+  onClear,
+  disabled,
+}: ImageDropzoneProps) => {
+  const { getRootProps, getInputProps, open, isDragActive } = useDropzone({
+    onDrop: (accepted) => {
+      const file = accepted[0]
+      if (file) onFile(file)
+    },
+    onDropRejected: (rejections) => {
+      rejections[0]?.errors.forEach((e) => {
+        const msg = dropErrors[e.code]
+        if (msg) toast.error(msg)
+      })
+    },
+    accept: { 'image/*': [] },
+    maxSize: 1024 * 1024,
+    multiple: false,
+    disabled,
+    noClick: true,
+    noKeyboard: true,
+  })
+
+  return (
+    <div className='space-y-2'>
+      <div
+        {...getRootProps({
+          className: cn(
+            'flex flex-col items-center justify-center rounded border-2 border-dashed p-4 text-center transition-colors hover:bg-muted/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50',
+            isDragActive && 'border-primary bg-primary/5',
+            disabled && 'opacity-50'
+          ),
+          role: 'button',
+          'aria-disabled': disabled,
+          'aria-describedby': 'icon-hint',
+        })}
+      >
+        <input {...getInputProps()} />
+        {preview ? (
+          <img src={preview} alt='Icon preview' className='h-16 w-16 rounded object-contain' />
+        ) : (
+          <div className='flex h-16 w-16 items-center justify-center rounded border text-xs text-muted-foreground'>
+            No image
+          </div>
+        )}
+        {disabled && (
+          <span className='mt-2 text-xs text-muted-foreground'>Uploading...</span>
+        )}
+      </div>
+      <div className='flex gap-2'>
+        <Button type='button' variant='outline' onClick={open} disabled={disabled}>
+          Choose File
+        </Button>
+        {preview && (
+          <Button type='button' variant='ghost' onClick={onClear} disabled={disabled}>
+            Clear
+          </Button>
+        )}
+      </div>
+      <p id='icon-hint' className='text-xs text-muted-foreground'>
+        Drag an image here or choose a file. Max 1MB.
+      </p>
+    </div>
+  )
+}

--- a/src/errors/media.ts
+++ b/src/errors/media.ts
@@ -1,0 +1,6 @@
+export const mediaErrors = {
+  load: 'Failed to load icon',
+  upload: 'Failed to upload icon',
+  type: 'Only image files allowed',
+  size: 'File too large (max 1MB)',
+} as const

--- a/src/features/quests/QuestForm.tsx
+++ b/src/features/quests/QuestForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { z } from 'zod'
 import { useForm, useWatch } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -26,11 +26,14 @@ import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
 import { SelectDropdown } from '@/components/select-dropdown'
+import { ImageDropzone } from '@/components/image-dropzone'
 import { uploadMedia } from './api'
 import { ChildrenEditor } from './components/children-editor'
 import type { Child } from './components/children-editor'
 import { groups, types, providers } from './data/data'
 import { withTwitterValidation } from './validation'
+import { replaceObjectUrl } from '@/utils/object-url'
+import { mediaErrors } from '@/errors/media'
 
 const childSchema = withTwitterValidation(
   z.object({
@@ -153,8 +156,10 @@ export const QuestForm = ({
   onCancel: () => void
 }) => {
   const auth = useAppAuth()
-  const fileRef = useRef<HTMLInputElement | null>(null)
   const [iconPreview, setIconPreview] = useState<string>()
+  const [isUploading, setIsUploading] = useState(false)
+  const clearIconPreview = () =>
+    setIconPreview((old) => replaceObjectUrl(old))
 
   const form = useForm({
     resolver: zodResolver(schema),
@@ -255,33 +260,33 @@ export const QuestForm = ({
   }, [form.formState.isDirty])
 
   const handleUpload = async (file: File) => {
-    if (!file.type.startsWith('image/')) {
-      toast.error('Only image files allowed')
-      return
-    }
-    if (file.size > 1024 * 1024) {
-      toast.error('File too large (max 1MB)')
-      return
-    }
+    setIconPreview((old) => replaceObjectUrl(old, file))
+    setIsUploading(true)
     try {
       const { url } = await uploadMedia(file, auth.getAccessToken())
       form.setValue('resources.icon', url, { shouldDirty: true })
     } catch {
-      toast.error('Failed to upload icon')
+      toast.error(mediaErrors.upload)
+      clearIconPreview()
+    } finally {
+      setIsUploading(false)
     }
   }
 
+  const handleClearIcon = () => {
+    form.setValue('resources.icon', undefined, { shouldDirty: true })
+    clearIconPreview()
+  }
+
   useEffect(() => {
+    if (!icon) {
+      clearIconPreview()
+      return
+    }
+    if (iconPreview) return
+
     const controller = new AbortController()
     let localUrl: string | undefined
-
-    if (!icon) {
-      setIconPreview((oldUrl) => {
-        if (oldUrl) URL.revokeObjectURL(oldUrl)
-        return undefined
-      })
-      return () => controller.abort()
-    }
 
     const load = async () => {
       try {
@@ -290,15 +295,16 @@ export const QuestForm = ({
           headers: token ? { Authorization: `Bearer ${token}` } : {},
           signal: controller.signal,
         })
+        if (!res.ok) throw new Error(String(res.status))
         const blob = await res.blob()
-        localUrl = URL.createObjectURL(blob)
         setIconPreview((oldUrl) => {
-          if (oldUrl) URL.revokeObjectURL(oldUrl)
-          return localUrl
+          const newUrl = replaceObjectUrl(oldUrl, blob)
+          localUrl = newUrl
+          return newUrl
         })
       } catch (e) {
         if (!(e instanceof DOMException && e.name === 'AbortError')) {
-          toast.error('Failed to load icon')
+          toast.error(mediaErrors.load)
         }
       }
     }
@@ -308,7 +314,7 @@ export const QuestForm = ({
       controller.abort()
       if (localUrl) URL.revokeObjectURL(localUrl)
     }
-  }, [icon, auth])
+  }, [icon, auth, iconPreview])
 
   return (
     <Form {...form}>
@@ -644,7 +650,6 @@ export const QuestForm = ({
                     </FormItem>
                   )}
                 />
-                // AdsGram Type
                 <FormField
                   control={form.control}
                   name='resources.adsgram.type'
@@ -678,7 +683,6 @@ export const QuestForm = ({
                     </FormItem>
                   )}
                 />
-                // AdsGram Subtype (only when type === 'task')
                 {adsgramType === 'task' && (
                   <FormField
                     control={form.control}
@@ -713,29 +717,12 @@ export const QuestForm = ({
 
         <div className='space-y-2'>
           <FormLabel>Icon</FormLabel>
-          {iconPreview ? (
-            <img
-              src={iconPreview}
-              className='h-16 w-16 rounded border object-contain'
-            />
-          ) : null}
-          <input
-            ref={fileRef}
-            type='file'
-            accept='image/*'
-            className='hidden'
-            onChange={async (e) => {
-              const f = e.target.files?.[0]
-              if (f) await handleUpload(f)
-            }}
+          <ImageDropzone
+            preview={iconPreview}
+            onFile={handleUpload}
+            onClear={handleClearIcon}
+            disabled={isUploading}
           />
-          <Button
-            type='button'
-            variant='outline'
-            onClick={() => fileRef.current?.click()}
-          >
-            Upload Icon
-          </Button>
         </div>
 
         <div className='flex gap-2'>

--- a/src/utils/object-url.ts
+++ b/src/utils/object-url.ts
@@ -1,0 +1,4 @@
+export const replaceObjectUrl = (prev?: string, next?: Blob) => {
+  if (prev) URL.revokeObjectURL(prev)
+  return next ? URL.createObjectURL(next) : undefined
+}


### PR DESCRIPTION
## Summary
- add reusable ImageDropzone component for drag-and-drop uploads with preview and validation
- replace manual file input in QuestForm with ImageDropzone and immediate preview
- improve accessibility and error handling with shared media error messages and object URL helper
- streamline uploader logic by removing duplicate handlers and centralizing preview cleanup

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68a0f2477c288328961982f919ea0aa0