### PR TITLE
fix(table): improve pagination and remove selected rows

### DIFF
--- a/src/components/table/data-table-pagination.tsx
+++ b/src/components/table/data-table-pagination.tsx
@@ -18,25 +18,25 @@ interface DataTablePaginationProps<TData> {
   table: Table<TData>
 }
 
-export function DataTablePagination<TData>({
+export const DataTablePagination = <TData,>({
   table,
-}: DataTablePaginationProps<TData>) {
+}: DataTablePaginationProps<TData>) => {
+  const pageCount = Math.max(table.getPageCount(), 1)
+
   return (
     <div
-      className='flex items-center justify-between overflow-clip px-2'
+      className='flex items-center justify-end overflow-clip px-2'
       style={{ overflowClipMargin: 1 }}
     >
-      <div className='text-muted-foreground hidden flex-1 text-sm sm:block'>
-        {table.getFilteredSelectedRowModel().rows.length} of{' '}
-        {table.getFilteredRowModel().rows.length} row(s) selected.
-      </div>
       <div className='flex items-center sm:space-x-6 lg:space-x-8'>
         <div className='flex items-center space-x-2'>
           <p className='hidden text-sm font-medium sm:block'>Rows per page</p>
           <Select
             value={`${table.getState().pagination.pageSize}`}
             onValueChange={(value) => {
-              table.setPageSize(Number(value))
+              const size = Number(value)
+              if (size === table.getState().pagination.pageSize) return
+              table.setPageSize(size)
             }}
           >
             <SelectTrigger className='h-8 w-[70px]'>
@@ -51,9 +51,8 @@ export function DataTablePagination<TData>({
             </SelectContent>
           </Select>
         </div>
-        <div className='flex w-[100px] items-center justify-center text-sm font-medium'>
-          Page {table.getState().pagination.pageIndex + 1} of{' '}
-          {table.getPageCount()}
+        <div className='flex min-w-[100px] items-center justify-center text-sm font-medium'>
+          Page {table.getState().pagination.pageIndex + 1} of {pageCount}
         </div>
         <div className='flex items-center space-x-2'>
           <Button
@@ -86,7 +85,7 @@ export function DataTablePagination<TData>({
           <Button
             variant='outline'
             className='hidden h-8 w-8 p-0 lg:flex'
-            onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+            onClick={() => table.setPageIndex(pageCount - 1)}
             disabled={!table.getCanNextPage()}
           >
             <span className='sr-only'>Go to last page</span>

--- a/src/features/quests/components/data-table.tsx
+++ b/src/features/quests/components/data-table.tsx
@@ -211,7 +211,7 @@ export const QuestsDataTable = ({ columns, isAdmin }: DataTableProps) => {
         pageIndex: Math.max(totalPages - 1, 0),
       }))
     }
-  }, [data?.total, pagination.pageSize, pagination.pageIndex])
+  }, [data?.total, pagination.pageSize, pagination.pageIndex, setPagination])
 
   return (
     <div className='space-y-4'>

--- a/src/features/quests/components/data-table.tsx
+++ b/src/features/quests/components/data-table.tsx
@@ -43,6 +43,10 @@ interface DataTableProps {
   isAdmin: boolean
 }
 
+// Single source for page count guards.
+const getSafePageCount = (total: number | undefined, size: number) =>
+  Math.max(1, Math.ceil((total ?? 0) / size))
+
 export const QuestsDataTable = ({ columns, isAdmin }: DataTableProps) => {
   const router = useRouter()
   const searchParams = useSearch({ from: '/_authenticated/quests/' as const })
@@ -170,7 +174,7 @@ export const QuestsDataTable = ({ columns, isAdmin }: DataTableProps) => {
   const table = useReactTable({
     data: (data?.items ?? []) as Quest[],
     columns: memoColumns,
-    pageCount: data ? Math.ceil(data.total / pagination.pageSize) : -1,
+    pageCount: getSafePageCount(data?.total, pagination.pageSize),
     state: { sorting, columnVisibility, columnFilters, pagination },
     manualPagination: true,
     manualSorting: true,
@@ -184,6 +188,8 @@ export const QuestsDataTable = ({ columns, isAdmin }: DataTableProps) => {
           typeof updater === 'function'
             ? (updater as (s: PaginationState) => PaginationState)(old)
             : updater
+        if (next.pageSize === old.pageSize && next.pageIndex === old.pageIndex)
+          return old
         return {
           pageIndex: next.pageSize !== old.pageSize ? 0 : next.pageIndex,
           pageSize: next.pageSize,
@@ -196,6 +202,16 @@ export const QuestsDataTable = ({ columns, isAdmin }: DataTableProps) => {
     getFacetedRowModel: getFacetedRowModel(),
     getFacetedUniqueValues: getFacetedUniqueValues(),
   })
+
+  React.useEffect(() => {
+    const totalPages = getSafePageCount(data?.total, pagination.pageSize)
+    if (pagination.pageIndex > totalPages - 1) {
+      setPagination((prev) => ({
+        ...prev,
+        pageIndex: Math.max(totalPages - 1, 0),
+      }))
+    }
+  }, [data?.total, pagination.pageSize, pagination.pageIndex])
 
   return (
     <div className='space-y-4'>


### PR DESCRIPTION
## Summary
- centralize safe page count calculation and snap page index to last page when data shrinks
- skip redundant page-size updates and simplify pagination controls

## Testing
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68a33ff0f79c8328997c6b6ef942c9db